### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/LolerhHero-github/38820b3e-736c-4bbb-a203-83d60ea174db/23eb6c43-66a3-42a4-8c98-7deab3f60af7/_apis/work/boardbadge/65633d53-8b7b-4277-ad42-c2584be9168d)](https://dev.azure.com/LolerhHero-github/38820b3e-736c-4bbb-a203-83d60ea174db/_boards/board/t/23eb6c43-66a3-42a4-8c98-7deab3f60af7/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/LolerhHero-github/Online_Calendar/_apis/build/status/LolerHero.Online_Calendar?branchName=master)](https://dev.azure.com/LolerhHero-github/Online_Calendar/_build/latest?definitionId=1&branchName=master)
 
 # Welcome to the Online Calendar!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/LolerhHero-github/38820b3e-736c-4bbb-a203-83d60ea174db/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.